### PR TITLE
Fix issue if Array has had its prototype extended

### DIFF
--- a/src/moment-round.js
+++ b/src/moment-round.js
@@ -23,15 +23,17 @@
     var maxValue ;
     for (var i in keys) {
       var k = keys[i];
-      if (k === key) {
-        value = this._d['get' + key]();
-        maxValue = maxValues[i];
-        rounded = true;
-      } else if(rounded) {
-        subRatio *= maxValues[i];
-        value += this._d['get' + k]() / subRatio;
-        this._d['set' + k](0);
-      }
+	    if (typeof k === "string"){
+        if (k === key) {
+          value = this._d['get' + key]();
+          maxValue = maxValues[i];
+          rounded = true;
+        } else if(rounded) {
+          subRatio *= maxValues[i];
+          value += this._d['get' + k]() / subRatio;
+          this._d['set' + k](0);
+        }
+	    }
     };
 
     value = Math[direction](value / precision) * precision;


### PR DESCRIPTION
In my project I have extended Array like so:
`Array.prototype.first = function () {}`

The loop starting on line 24 also loops prototype extensions, which leads to a "is not a function" error.
This patch checks that k is a string before proceeding to use it.
