### PR TITLE
Fix issue if Array has had its prototype extended

### DIFF
--- a/src/moment-round.js
+++ b/src/moment-round.js
@@ -23,11 +23,11 @@
     var maxValue ;
     for (var i in keys) {
       var k = keys[i];
-      if (k === key) {
+      if (k === key && typeof this._d['get' + key] === "function") {
         value = this._d['get' + key]();
         maxValue = maxValues[i];
         rounded = true;
-      } else if(rounded) {
+      } else if(rounded && typeof this._d['get' + k] === "function") {
         subRatio *= maxValues[i];
         value += this._d['get' + k]() / subRatio;
         this._d['set' + k](0);


### PR DESCRIPTION
In my project I have extended Array like so:
`Array.prototype.first = function ();`

This causes an issue as the loop on [Line 24](https://github.com/WebDevTmas/moment-round/blob/master/src/moment-round.js#L24) also includes Array prototype properties leading to a "is not a function error".
This pull request ensures that the function about to to be called is indeed a function first.
