### PR TITLE
Fix peer dependency syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     
   },
   "peerDependencies": {
-    "moment": ">= 2"
+    "moment": ">=2.0.0"
   }
 }


### PR DESCRIPTION
Despite using moment 2.0.1 we were receiving peer dependency errors in certain npm versions. It seems the semver syntax in _peerDependencies_ used cannot be parsed by certain npm versions. This PR fixes this issue.

Thanks!
